### PR TITLE
build: update swift-collections

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "branch" : "origin/release/1.1",
-        "revision" : "5fab05b1ea1d65f3057dd8caa3d819eb18984022"
+        "branch" : "main",
+        "revision" : "427083e64d5c4321fd45654db48f1e7682d2798e"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-collections", branch: "origin/release/1.1"),
+        .package(url: "https://github.com/apple/swift-collections", branch: "main"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
I switched to main from release/1.1 because swift-collections 1.1 drops BitArray's bitwise operators.