### PR TITLE
chore: disable actor data race checking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,6 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),
                 .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=100"], .when(configuration: .debug)),
-                .unsafeFlags(["-Xfrontend", "-enable-actor-data-race-checks"]),
                 .unsafeFlags(["-O"]),
                 .unsafeFlags(["-cross-module-optimization"]),
                 .enableUpcomingFeature("ExistentialAny"),


### PR DESCRIPTION
This flag sometimes causes a runtime crash.