### PR TITLE
refactor: replace `_read` and `_modify` with `borrow` and `mutate`

### DIFF
--- a/Sources/GameOfLife/CellularAutomaton.swift
+++ b/Sources/GameOfLife/CellularAutomaton.swift
@@ -150,7 +150,7 @@ public struct CellularAutomaton {
     /// Accesses the cell at the specified position.
     @inlinable
     public subscript(x: Int, y: Int) -> Bool {
-        _read { yield self.map[y][x] }
-        _modify { yield &self.map[y][x] }
+        borrow { self.map[y][x] }
+        mutate { &self.map[y][x] }
     }
 }


### PR DESCRIPTION
These new accessors are introduced by
[SE-0507](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0507-borrow-accessors.md), so require Swift 6.4.