### PR TITLE
build: fix a warning that swift-collections is unused

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,8 @@ let package = Package(
             dependencies: [
                 .target(name: "GameOfLife"),
                 .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
+                .product(name: "DequeModule", package: "swift-collections"),
             ],
             swiftSettings: [
                 .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),


### PR DESCRIPTION
swift-collections is not a direct dependency, but it is required to specify its version constraint explicitly because Swift Playground 4.7 can't build swift-collections 1.4.0 and later. The `OrderedCollections` and `DequeModule` are used within swift-async-algorithms.