### PR TITLE
build: enable strict checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - run: |
           "$SWIFT" --version
       - run: |
-          "$SWIFT" build --sdk "$(xcrun --sdk iphoneos --show-sdk-path)" --triple arm64-apple-ios
+          "$SWIFT" build --sdk "$(xcrun --sdk iphoneos --show-sdk-path)" --triple arm64-apple-ios --explicit-target-dependency-import-check error
   lint:
     runs-on: ubuntu-24.04-arm
     container: swift:6.2

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,8 @@ let package = Package(
                 .enableUpcomingFeature("MemberImportVisibility"),
                 .enableUpcomingFeature("InferIsolatedConformances"),
                 .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+                .strictMemorySafety(),
+                .treatAllWarnings(as: .error),
             ]
         ),
         .executableTarget(
@@ -52,6 +54,8 @@ let package = Package(
                 .enableUpcomingFeature("MemberImportVisibility"),
                 .enableUpcomingFeature("InferIsolatedConformances"),
                 .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+                .strictMemorySafety(),
+                .treatAllWarnings(as: .error),
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -45,8 +45,9 @@ let package = Package(
                 .product(name: "DequeModule", package: "swift-collections"),
             ],
             swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),
-                .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=100"], .when(configuration: .debug)),
+                // FIXME: Cannot treat these warnings as warnings
+                // .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),
+                // .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=100"], .when(configuration: .debug)),
                 .unsafeFlags(["-O"]),
                 .unsafeFlags(["-cross-module-optimization"]),
                 .enableUpcomingFeature("ExistentialAny"),

--- a/Sources/GameOfLife/BitField.swift
+++ b/Sources/GameOfLife/BitField.swift
@@ -14,9 +14,9 @@
         let (q, r) = count.quotientAndRemainder(dividingBy: UInt.bitWidth)
         let innerCount = r > 0 ? q + 1 : q
         return .init(
-            inner: .init(unsafeUninitializedCapacity: innerCount) { buf, count in
+            inner: unsafe .init(unsafeUninitializedCapacity: innerCount) { buf, count in
                 for i in 0..<innerCount {
-                    buf[i] = .random(in: UInt.min...UInt.max)
+                    unsafe buf[i] = .random(in: UInt.min...UInt.max)
                 }
                 count = innerCount
             },


### PR DESCRIPTION
- [Strict Memory Safety](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0458-strict-memory-safety.md)
- [Treat all warnings as errors](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0480-swiftpm-warning-control.md)
- `--explicit-target-dependency-import-check error` in CI